### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ get larger files from common open-access data repositories.
 ## Installing and usage
 To install:
 ```bash
-pip install --user scikit-hep-testdata
+pip install scikit-hep-testdata
 ```
 
 Once installed, absolute file paths can be resolved using the helper methods:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI version](https://img.shields.io/pypi/v/scikit-hep-testdata.svg?longCache=true)](https://pypi.org/project/scikit-hep-testdata/)
-[![Build Status](https://travis-ci.org/scikit-hep/scikit-hep-testdata.svg?branch=master)](https://travis-ci.org/scikit-hep/scikit-hep-testdata)
+[![Build Status](https://travis-ci.com/scikit-hep/scikit-hep-testdata.svg?branch=master)](https://travis-ci.com/scikit-hep/scikit-hep-testdata)
 [![codecov](https://img.shields.io/codecov/c/github/scikit-hep/scikit-hep-testdata/master.svg?longCache=true)](https://codecov.io/gh/scikit-hep/scikit-hep-testdata)
 
 scikit-hep-testdata


### PR DESCRIPTION
A small fix to the README to fix the URLs for the build badges before we put things on pypi.