### PR TITLE
Simplification of version number setting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.1
-commit = True
-tag = False
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:skhep_testdata/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -24,4 +11,3 @@ test = pytest
 collect_ignore = ['setup.py']
 addopts = -v -x --doctest-modules --ignore=setup.py --cov=skhep_testdata --pep8
 pep8maxlinelength = 120
-

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,23 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
+import os.path
+
 from setuptools import setup, find_packages
 
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
+def get_version():
+    g = {}
+    exec(open(os.path.join("skhep_testdata", "version.py")).read(), g)
+    return g["__version__"]
 
 setup(
     author="Ben Krikler",
     author_email='b.krikler@cern.ch',
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
+        'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
@@ -37,6 +43,6 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest-cov', 'pytest-pep8'],
     url='https://github.com/scikit-hep/scikit-hep-testdata',
-    version='0.1.1',
+    version = get_version(),
     zip_safe=True,
 )

--- a/skhep_testdata/__init__.py
+++ b/skhep_testdata/__init__.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 
 from .local_files import data_path
 
-
-__all__ = ["data_path"]
-
 # Convenient access to the version number
 from .version import __version__
+
+__all__ = ["data_path"]

--- a/skhep_testdata/__init__.py
+++ b/skhep_testdata/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
+
 from .local_files import data_path
 
 
 __all__ = ["data_path"]
-__version__ = '0.1.1'
+
+# Convenient access to the version number
+from .version import __version__

--- a/skhep_testdata/version.py
+++ b/skhep_testdata/version.py
@@ -1,0 +1,4 @@
+__version__ = '0.1.1'
+
+version = __version__
+version_info = __version__.split('.')

--- a/skhep_testdata/version.py
+++ b/skhep_testdata/version.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 version = __version__
 version_info = __version__.split('.')


### PR DESCRIPTION
This way the version number is only set in one place, which is also less error prone.