### PR TITLE
Adding GHA, fixing deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: master
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - 2.7
+        - 3.6
+        - 3.8
+    name: Check Python ${{ matrix.python-version }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install package
+      run: python -m pip install -e .[test]
+
+    - name: Requirements check
+      run: python -m pip list
+
+    - name: Test package
+      run: python -m pytest
+
+
+  dist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Install wheel and sdist requirements
+      run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=3.4" "wheel"
+
+    - name: Build sdist
+      run: python setup.py sdist
+
+    - name: Build wheel
+      run: >
+        python -m pip wheel . -w wheels &&
+        ls -lh wheels &&
+        cp wheels/scikit?hep?testdata*any.whl dist/
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: DistPackage
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_password }}
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,15 @@ jobs:
     - name: Install wheel and sdist requirements
       run: python -m pip install "setuptools>=42.0" "setuptools_scm[toml]>=3.4" "wheel"
 
-    - name: Build sdist
-      run: python setup.py sdist
+      # There's no reason to produce an sdist, and it's already big
+      # - name: Build sdist
+      #   run: python setup.py sdist
 
     - name: Build wheel
       run: >
         python -m pip wheel . -w wheels &&
         ls -lh wheels &&
+        mkdir -p dist &&
         cp wheels/scikit?hep?testdata*any.whl dist/
 
     - uses: actions/upload-artifact@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 install:
     - echo $TRAVIS_PYTHON_VERSION
     - pip list
-    - pip install codecov "setuptools>=42" "setuptools_scm"
+    - pip install codecov "setuptools>=42" "setuptools_scm[toml]>=3.4"
     - pip install .[test]
 
 script:
@@ -18,16 +18,3 @@ after_success:
     - coverage combine
     - codecov
 
-before_deploy:
-    - python -m pip install "setuptools>=42.0" "setuptools_scm"
-
-deploy:
-    provider: pypi
-    user: ben.krikler
-    password:
-        secure: RqWm22z8MibNDEDggROCg4iAUqSp4EsetRTct5oQ+2d/DT4wbOhgb4wkKuVN7o+cCKxtWoQvosd7a4bKMvUHgYTy4mMK8t1z/1E7PxGzOXxF1xV5ddXEQAYRp9jI9v5Fy94HhzFKr2Ev318lEjU/GrwwFIuM68OHJ0j0J2PVNQwA0aGWoHUGvu5WLL/a0wTgigOaq0Xmh/JmoaSDMRV+CWSeowuMarqHwKkFJ+Upok1hDikc5vOmebEKLdncDZvGd0zpgMrST/20gvE75G3Ab4YzR9uuM7D8nLh0ahOnA5+yagNUC8QkMvX9vdTChb6y95CEEBBq/zf/P+CNvCKMJREZXm5PoNkn61/CaDmypKXWFJxNb/SnIbGuPnSBZIwf84lNzITCh4/B4D0sWyC2PpwtPic8It6RS2II/8sdjpicg1eKcOov9pVCE6AEHegltJpuKXmaogqSVyCFbN2sRgcONDE7aryDubGPLg7x6dwj9ow/H+nKoUEHDpIM1fNAlX5YQ6vvL8YkUZxsEBWppQTUFd4M235cu1LrKm8xlt1wyFJ0DuYvgdB93zdcV7tue7f8Y+iJdKo2GBnRqiwqFkKqQGgzbzgISzuGt0Simz6muWckjW1n986ztfxu8g2FW7v1kyehrnTzFXU6Xv9J+4RClCbxBPLW7Npk/0tQKcQ=
-    distributions: "sdist bdist_wheel --universal"
-    on:
-        tags: true
-        branch: master
-        condition: '$TRAVIS_PYTHON_VERSION = "3.6"'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![PyPI version](https://img.shields.io/pypi/v/scikit-hep-testdata.svg?longCache=true)](https://pypi.org/project/scikit-hep-testdata/)
+[![Github Actions badge](https://github.com/scikit-hep/scikit-hep-testdata/workflows/CI/badge.svg)](https://github.com/scikit-hep/scikit-hep-testdata/actions)
 [![Build Status](https://travis-ci.com/scikit-hep/scikit-hep-testdata.svg?branch=master)](https://travis-ci.com/scikit-hep/scikit-hep-testdata)
 [![codecov](https://img.shields.io/codecov/c/github/scikit-hep/scikit-hep-testdata/master.svg?longCache=true)](https://codecov.io/gh/scikit-hep/scikit-hep-testdata)
 


### PR DESCRIPTION
Adding GitHub Actions. This should also fix the deploy once we make a token and add the secret.

We can drop Travis if we add codecov to GHA.