### PR TITLE
Update URL for HEPTutorial_0.tar

### DIFF
--- a/src/skhep_testdata/remote_datasets.yml
+++ b/src/skhep_testdata/remote_datasets.yml
@@ -3,7 +3,7 @@
 # Each value in the top level is a dictionary giving the URL and files contained in the dataset.
 
 cms_hep_2012_tutorial:
-    url: http://ippog.org/sites/ippog.web.cern.ch/files/HEPTutorial_0.tar
+    url: http://opendata.cern.ch/record/212/files/HEPTutorial_0.tar
     files:
         data.root:       HEPTutorial/files/data.root
         dy.root:         HEPTutorial/files/dy.root


### PR DESCRIPTION
The current URL 404s: http://ippog.org/sites/ippog.web.cern.ch/files/HEPTutorial_0.tar