### PR TITLE
Put "Scikit-HEP Administrators" as copyright holders and update copyright to 2022

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018, Ben Krikler
+Copyright (c) 2018-2022, The Scikit-HEP Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2022, The Scikit-HEP Developers.
+Copyright (c) 2018-2022, The Scikit-HEP Administrators.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
+# scikit-hep-testdata
+
+[![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 [![PyPI version](https://img.shields.io/pypi/v/scikit-hep-testdata.svg?longCache=true)](https://pypi.org/project/scikit-hep-testdata/)
 [![Github Actions badge](https://github.com/scikit-hep/scikit-hep-testdata/workflows/CI/badge.svg)](https://github.com/scikit-hep/scikit-hep-testdata/actions)
 [![Coverage Status](https://coveralls.io/repos/github/scikit-hep/scikit-hep-testdata/badge.svg?branch=main)](https://coveralls.io/github/scikit-hep/scikit-hep-testdata?branch=main)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/scikit-hep/scikit-hep-testdata/main.svg)](https://results.pre-commit.ci/latest/github/scikit-hep/scikit-hep-testdata/main)
-[![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 
 [sk-badge]: https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
-
-scikit-hep-testdata
-===================
 
 A common package to provide example files (*e.g*. ROOT) for testing and developing packages against.
 The sample of files is representative of typical files found "in the wild".
@@ -19,7 +18,7 @@ get larger files from common open-access data repositories.
 To install:
 
 ```bash
-pip install scikit-hep-testdata
+python -m pip install scikit-hep-testdata
 ```
 
 Once installed, absolute file paths can be resolved using the helper methods:


### PR DESCRIPTION
Hi @benkrikler, and Happy New Year, first of all!

I am here making the suggestion to change the copyright holder from you to "The Scikit-HEP Administrators" as in other places in the org as it makes more sense, at least in my opinion (not the least you have not been contributing to the package for the past 3 years). Is that OK with you? For obvious reasons you should advise :-). Thanks.
