### PR TITLE
build: Support Python 3.6+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,17 +3,6 @@ ci:
   autoupdate_schedule: "quarterly"
 
 repos:
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.38.2
-  hooks:
-  - id: pyupgrade
-    args: ["--py36-plus"]
-
-- repo: https://github.com/psf/black
-  rev: 22.8.0
-  hooks:
-  - id: black
-
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
   hooks:
@@ -27,7 +16,17 @@ repos:
   - id: mixed-line-ending
   - id: requirements-txt-fixer
   - id: trailing-whitespace
-  - id: fix-encoding-pragma
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.38.2
+  hooks:
+  - id: pyupgrade
+    args: ["--py36-plus"]
+
+- repo: https://github.com/psf/black
+  rev: 22.8.0
+  hooks:
+  - id: black
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
   rev: v2.38.2
   hooks:
   - id: pyupgrade
+    args: ["--py36-plus"]
 
 - repo: https://github.com/psf/black
   rev: 22.8.0
@@ -37,7 +38,7 @@ repos:
   rev: v2.0.0
   hooks:
   - id: setup-cfg-fmt
-    args: [--min-py3-version=3.5]
+    args: [--include-version-classifiers, --max-py-version=3.10]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v0.981

--- a/dev/make-root/uproot-issue38c.py
+++ b/dev/make-root/uproot-issue38c.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This example will produce a ROOT file with a TEfficiency with fBeta_bin_params filled.
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,9 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Natural Language :: English
-    Programming Language :: Python :: 2
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: Implementation :: CPython
     Typing :: Typed
 keywords =
     ROOT
@@ -29,9 +30,7 @@ install_requires =
     pyyaml
     requests
     importlib-resources>=1.3;python_version<"3.9"
-    pathlib2>=2.1.0;python_version<"3"
-    typing;python_version<"3.5"
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.6
 package_dir =
     =src
 zip_safe = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,11 @@ classifiers =
     Natural Language :: English
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Typing :: Typed
 keywords =

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,9 +47,6 @@ console_scripts =
 test =
     pytest>=4.0.0
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 ignore = E203, E231, E501, E722, W503, B950
@@ -77,7 +74,7 @@ exclude_lines =
 
 [mypy]
 files = src
-python_version = 2.7
+python_version = 3.6
 warn_unused_configs = True
 disallow_any_generics = True
 disallow_subclassing_any = True

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
-from __future__ import print_function
 
 import os
 
@@ -30,7 +29,7 @@ opts = {"include_package_data": True}
 include_data = bool(os.environ.get("SKHEP_DATA"))
 if not include_data:
     opts["exclude_package_data"] = {
-        "": ["*{}".format(ex) for ex in data_ex],
+        "": [f"*{ex}" for ex in data_ex],
     }
     opts["cmdclass"] = {"sdist": SDist}
 

--- a/src/skhep_testdata/__init__.py
+++ b/src/skhep_testdata/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from typing import Tuple
 
 from .local_files import data_path, download_all, known_files

--- a/src/skhep_testdata/__init__.py
+++ b/src/skhep_testdata/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 from typing import Tuple
 
 from .local_files import data_path, download_all, known_files

--- a/src/skhep_testdata/__main__.py
+++ b/src/skhep_testdata/__main__.py
@@ -6,7 +6,6 @@ This file will be invoked by python when called with th `-m` options:
 python -m skhep_testdata cms_hep_2012_tutorial/data.root
 ```
 """
-from __future__ import print_function
 
 import argparse
 

--- a/src/skhep_testdata/__main__.py
+++ b/src/skhep_testdata/__main__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This file will be invoked by python when called with th `-m` options:
 

--- a/src/skhep_testdata/local_files.py
+++ b/src/skhep_testdata/local_files.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import sys
 import tempfile
 import zipfile

--- a/src/skhep_testdata/local_files.py
+++ b/src/skhep_testdata/local_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 import tempfile
 import zipfile

--- a/src/skhep_testdata/local_files.py
+++ b/src/skhep_testdata/local_files.py
@@ -3,18 +3,13 @@ from __future__ import absolute_import
 
 import sys
 import tempfile
-import typing
 import zipfile
-from typing import Any, Optional
+from pathlib import Path
+from typing import Optional
 
 import requests
 
 from . import data, remote_files
-
-if sys.version_info < (3, 5):
-    from pathlib2 import Path
-else:
-    from pathlib import Path
 
 if sys.version_info < (3, 9):
     import importlib_resources as resources
@@ -38,11 +33,7 @@ def _cache_path(cache_dir=None):
     # type: (Optional[str]) -> Path
     if cache_dir is None:
         skhepdir = Path.home() / ".local" / "skhepdata"
-        # But in typeshed - https://github.com/python/typeshed/pull/5218
-        if sys.version_info < (3, 5):
-            typing.cast(Any, skhepdir.mkdir)(exist_ok=True, parents=True)
-        else:
-            skhepdir.mkdir(exist_ok=True, parents=True)
+        skhepdir.mkdir(exist_ok=True, parents=True)
         return skhepdir
     else:
         return Path(cache_dir)
@@ -54,10 +45,7 @@ def data_path(filename, raise_missing=True, cache_dir=None):
         return remote_files.remote_file(filename, raise_missing=raise_missing)
 
     if filename not in known_files and raise_missing:
-        if sys.version_info < (3,):
-            raise IOError(filename)
-        else:
-            raise FileNotFoundError(filename)
+        raise FileNotFoundError(filename)
 
     filepath = DIR / "data" / filename
 

--- a/src/skhep_testdata/remote_files.py
+++ b/src/skhep_testdata/remote_files.py
@@ -4,15 +4,10 @@ import logging
 import os
 import sys
 import tarfile
-import typing
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
+from urllib.request import urlretrieve
 
 import yaml
-
-if sys.version_info < (3,):
-    from urllib import urlretrieve
-else:
-    from urllib.request import urlretrieve
 
 if sys.version_info < (3, 9):
     import importlib_resources as resources
@@ -90,10 +85,7 @@ def fetch_remote_dataset(dataset_name, files, url, data_dir):
 
     make_all_dirs(dataset_dir)
     logging.warning("Downloading {}".format(url))
-    if sys.version_info < (3,):
-        typing.cast(Any, urlretrieve)(url, writefile)
-    else:
-        urlretrieve(url, writefile)
+    urlretrieve(url, writefile)
 
     if tarfile.is_tarfile(writefile):
         logging.warning("Extracting {}".format(writefile))

--- a/src/skhep_testdata/remote_files.py
+++ b/src/skhep_testdata/remote_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import errno
 import logging
 import os

--- a/src/skhep_testdata/remote_files.py
+++ b/src/skhep_testdata/remote_files.py
@@ -17,7 +17,7 @@ else:
 _default_data_dir = os.path.realpath(os.path.dirname(__file__))
 
 
-class RemoteDatasetList(object):
+class RemoteDatasetList:
     _all_files = {}  # type: Dict[str, Dict[str, str]]
 
     @classmethod
@@ -44,7 +44,7 @@ class RemoteDatasetList(object):
             with dataset_yml.open() as infile:
                 datasets = yaml.load(infile, Loader=yaml.SafeLoader)
         else:
-            with open(file_to_load, "r") as infile:
+            with open(file_to_load) as infile:
                 datasets = yaml.load(infile, Loader=yaml.SafeLoader)
 
         for dataset, config in datasets.items():
@@ -84,11 +84,11 @@ def fetch_remote_dataset(dataset_name, files, url, data_dir):
         return
 
     make_all_dirs(dataset_dir)
-    logging.warning("Downloading {}".format(url))
+    logging.warning(f"Downloading {url}")
     urlretrieve(url, writefile)
 
     if tarfile.is_tarfile(writefile):
-        logging.warning("Extracting {}".format(writefile))
+        logging.warning(f"Extracting {writefile}")
         with tarfile.open(writefile) as tar:
             members = [tar.getmember(f) for f in files.values()]
             tar.extractall(dataset_dir, members)

--- a/tests/test_local_files.py
+++ b/tests/test_local_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import pytest

--- a/tests/test_remote_files.py
+++ b/tests/test_remote_files.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import skhep_testdata as skhtd


### PR DESCRIPTION
Following removal of testing for Python < 3.5 in PR #77, codify this by dropping Python 2.7 and Python 3.5 support.

* Remove support for Python 2.7 and Python 3.5.
* Remove Python 2.7 and 3.5 only install_requires.
* Remove Python version guards for Python < 3 and < 3.5.
* Update pre-commit hooks to Python 3.6+.