### PR TITLE
chore: update CI actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
+        - '3.12'
     name: Check Python ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,16 +47,15 @@ jobs:
       run: python -m pytest ./tests --cov=src/skhep_testdata --cov-report=xml
 
     - name: Test coverage with Codecov
-      if: matrix.python-version != 3.7
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
 
   dist:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -65,12 +65,12 @@ jobs:
     - name: Show sizes
       run: ls -lh dist
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       with:
         name: DistPackage
         path: dist
 
-    - uses: pypa/gh-action-pypi-publish@v1.4.2
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
The version of the actions that were used in the CI were very old and needed to be updated. I changed them all to their latest version, and I added a `dependabot.yml` file to keep them up to date.

Also, removed Python 3.7 from being tested since it seems to be causing some trouble (see e.g. #141). I added testing of Python 3.11 and 3.12. It would probably make sense to officially drop support for Python 3.7 soon since it has reached its end of life.