### PR TITLE
fix: CLI --dir passed as raise_missing instead of cache_dir

### DIFF
--- a/src/skhep_testdata/__main__.py
+++ b/src/skhep_testdata/__main__.py
@@ -39,7 +39,7 @@ def main():
         download_all(args.dir)
 
     for p in args.file_path:
-        path = data_path(p, args.dir)
+        path = data_path(p, cache_dir=args.dir)
         print(path)
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

The CLI passed `--dir` to the wrong parameter of `data_path`:

```python
path = data_path(p, args.dir)
```

The signature is `data_path(filename, raise_missing=True, cache_dir=None)`, so `args.dir` was bound to `raise_missing` rather than `cache_dir`. As a result `skhep-testdata --dir <path> <file>` did not change the cache location, and passing `--dir` turned the value into a truthy/None `raise_missing` flag instead.

## Fix

Pass it as a keyword:

```python
path = data_path(p, cache_dir=args.dir)
```